### PR TITLE
fix(jackson): implement same order for static imports

### DIFF
--- a/src/main/java/io/github/timoa/misc/JacksonImportStyle.java
+++ b/src/main/java/io/github/timoa/misc/JacksonImportStyle.java
@@ -39,9 +39,20 @@ public class JacksonImportStyle extends NamedStyles {
                 .blankLine()
                 .importPackage("com.fasterxml.jackson.other.modules.*")
                 .blankLine()
+                // and the same for static
+                .staticImportPackage("java.*")
+                .blankLine()
                 .importStaticAllOthers()
+                .blankLine()
+                .staticImportPackage("com.fasterxml.jackson.annotation.*")
+                .blankLine()
+                .staticImportPackage("com.fasterxml.jackson.core.*")
+                .staticImportPackage("com.fasterxml.jackson.databind.*")
+                .staticImportPackage("tools.jackson.*")//needed for master
+                .blankLine()
+                .staticImportPackage("com.fasterxml.jackson.other.modules.*")
                 .classCountToUseStarImport(Integer.MAX_VALUE)//disable collapsing imports to *
-                .nameCountToUseStarImport(Integer.MAX_VALUE)//disable collapsing imports to *
+                .nameCountToUseStarImport(Integer.MAX_VALUE)//disable collapsing static imports to *
                 .build();
     }
 

--- a/src/test/java/io/github/timoa/misc/JacksonImportStyleTest.java
+++ b/src/test/java/io/github/timoa/misc/JacksonImportStyleTest.java
@@ -154,4 +154,54 @@ class JacksonImportStyleTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void exampleWithStaticImports() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().styles(
+            singletonList(
+              new JacksonImportStyle())
+          )),
+          java(
+            """
+              package com.fasterxml.jackson.core.write;
+
+              import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_COMMENTS;
+              import com.fasterxml.jackson.core.*;
+
+              import static java.nio.charset.StandardCharsets.UTF_8;
+              import java.io.*;
+
+              import static org.junit.jupiter.api.Assertions.*;
+              import static org.assertj.core.error.ActualIsNotEmpty.actualIsNotEmpty;
+
+              import org.junit.jupiter.api.Test;
+
+              class Test {
+              }
+              """,
+            """
+              package com.fasterxml.jackson.core.write;
+
+              import java.io.*;
+
+              import org.junit.jupiter.api.Test;
+
+              import com.fasterxml.jackson.core.*;
+
+              import static java.nio.charset.StandardCharsets.UTF_8;
+
+              import static org.assertj.core.error.ActualIsNotEmpty.actualIsNotEmpty;
+              import static org.junit.jupiter.api.Assertions.*;
+
+              import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_COMMENTS;
+
+              class Test {
+              }
+              """
+          )
+        );
+    }
+
+
 }


### PR DESCRIPTION
order for static imports is currently alphabetical. This PR implements the same order for them as there is for non-static imports.